### PR TITLE
Include frame.h for RISC-V

### DIFF
--- a/sys/arch/riscv64/TODO.md
+++ b/sys/arch/riscv64/TODO.md
@@ -1,1 +1,2 @@
 check sigcontext struct (stolen from freebsd) in include/signal.h
+review if necessary to include FP regs in trapframe in include/frame.h

--- a/sys/arch/riscv64/include/frame.h
+++ b/sys/arch/riscv64/include/frame.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019 Brian Bamsch <bbamsch@google.com>
+ * Copyright (c) 2016 Dale Rahn <drahn@dalerahn.com>
+ * Copyright (c) 2015 Ruslan Bukin <br@bsdpad.com>
+ * All rights reserved.
+ *
+ * Portions of this software were developed by SRI International and the
+ * University of Cambridge Computer Laboratory under DARPA/AFRL contract
+ * FA8750-10-C-0237 ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Portions of this software were developed by the University of Cambridge
+ * Computer Laboratory as part of the CTSRD Project, with support from the
+ * UK Higher Education Innovation Fund (HEIF).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE_FRAME_H_
+#define _MACHINE_FRAME_H_
+
+#ifndef _LOCORE
+
+#include <sys/signal.h>
+
+/*
+ * Exception/Trap Stack Frame
+ */
+#define clockframe trapframe
+typedef struct trapframe {
+	/* Standard Registers */
+	int64_t tf_ra;
+	int64_t tf_sp;
+	int64_t tf_gp;
+	int64_t tf_tp;
+	int64_t tf_t[7];
+	int64_t tf_s[12];
+	int64_t tf_a[8];
+	/* Supervisor Trap CSRs */
+	int64_t tf_sepc;
+	int64_t tf_sstatus;
+	int64_t tf_stval;
+	int64_t tf_scause;
+} trapframe_t;
+
+/*
+ * pushed on stack for signal delivery
+ */
+struct sigframe {
+	int sf_signum;
+	struct sigcontext sf_sc;
+	siginfo_t sf_si;
+};
+
+/*
+ * System stack frames.
+ */
+
+/*
+ * Stack frame inside cpu_switch()
+ */
+struct switchframe {
+	int64_t sf_s[12];
+};
+
+struct callframe {
+	struct callframe *f_frame;
+	int64_t f_ra;
+};
+
+#endif /* !_LOCORE */
+
+#endif /* !_MACHINE_FRAME_H_ */


### PR DESCRIPTION
Portions of frame.h were derived from the FreeBSD/riscv
implementation of frame.h written by Ruslan Bukin and the
OpenBSD/arm64 implementation of frame.h written by Dale Rahn.
Retain compatible copyright notice from reference files.