### PR TITLE
Add trap.h for RISC-V

### DIFF
--- a/sys/arch/riscv64/include/trap.h
+++ b/sys/arch/riscv64/include/trap.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Brian Bamsch <bbamsch@google.com>
+ * Copyright (c) 2016 Dale Rahn <drahn@dalerahn.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define KERNEL_BREAKPOINT	0x00100073	/* EBREAK -- Used by DDB */
+
+#define KBPT_ASM		"ebreak"
+
+#define USER_BREAKPOINT		0x00100073	/* EBREAK */


### PR DESCRIPTION
Includes aliases for breakpoint instructions. These all map to the same
thing as the breakpoint (ebreak) instruction should be reusable between
kernel and user modes.