### PR TITLE
Set explicit compile target in Makefile.riscv64

### DIFF
--- a/sys/arch/riscv64/conf/Makefile.riscv64
+++ b/sys/arch/riscv64/conf/Makefile.riscv64
@@ -41,7 +41,7 @@ CWARNFLAGS=	-Werror -Wall -Wimplicit-function-declaration \
 		-Wno-constant-conversion -Wno-address-of-packed-member \
 		-Wframe-larger-than=2047
 
-CMACHFLAGS=	-march=rv64gc \
+CMACHFLAGS=	--target=riscv64-unknown-openbsd6.6 -march=rv64gc \
 		-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
 CMACHFLAGS+=	-ffreestanding ${NOPIE_FLAGS}
 SORTR=		sort -R


### PR DESCRIPTION
This will likely be necessary until we get to the point of bootstrapping
OpenBSD on RISC-V.