### PR TITLE
Stub out the riscv64 mainbus

### DIFF
--- a/sys/arch/riscv64/TODO.md
+++ b/sys/arch/riscv64/TODO.md
@@ -9,3 +9,4 @@ Look into implementing riscv64/cpufunc.c, if necessary
 
 DDB is completely unimplemented. Don't expect it to work.
 PMAP is missing quite a few pieces (TLB Flush, etc.)
+Mainbus does not attach sub-devices. It should probably attach the "cpu" device

--- a/sys/arch/riscv64/dev/mainbus.c
+++ b/sys/arch/riscv64/dev/mainbus.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016 Patrick Wildt <patrick@blueri.se>
+ * Copyright (c) 2017 Mark Kettenis <kettenis@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/device.h>
+
+int mainbus_match(struct device *, void *, void *);
+void mainbus_attach(struct device *, struct device *, void *);
+int mainbus_print(void *, const char *);
+
+const struct cfattach mainbus_ca = {
+	sizeof(struct device), mainbus_match, mainbus_attach
+};
+
+struct cfdriver mainbus_cd = {
+	NULL, "mainbus", DV_DULL
+};
+
+int
+mainbus_match(struct device *parent, void *cfdata, void *aux)
+{
+	// XXX Is logic this necessary? Should we always attach?
+	static int mainbus_attached = 0;
+
+	if (mainbus_attached != 0)
+		return 0;
+
+	return mainbus_attached = 1;
+}
+
+void
+mainbus_attach(struct device *parent, struct device *self, void *aux)
+{
+	// XXX Mainbus attach. Should probably attach "cpu".
+}
+
+int
+mainbus_print(void *aux, const char *pnp)
+{
+	return (pnp ? QUIET : UNCONF);
+}


### PR DESCRIPTION
Simply match against the first call to mainbus_match and nothing else. The mainbus should attach the CPU device (as outlined in riscv64.files).