### PR TITLE
Platform Interrupt Controller & CPU Switch

### DIFF
--- a/sys/arch/riscv64/TODO.md
+++ b/sys/arch/riscv64/TODO.md
@@ -17,8 +17,6 @@
 * DDB
     * Completely unimplemented. Don't expect it to work.
 * PMAP
-    * Do not expect page table switch to work yet.
-    * PMAP structure's pm\_mode is not set. This will definitely cause issues later.
     * Consolidate pm\_mode / pm\_asid / pm\_ppn into single var -- pm\_satp?
     * Physmap vars necessary in bootconfig.h?
 * Interrupts

--- a/sys/arch/riscv64/dev/plic.c
+++ b/sys/arch/riscv64/dev/plic.c
@@ -43,11 +43,11 @@
 
 #define	PLIC_PRIORITY(n)	(PLIC_PRIORITY_BASE + (n) * sizeof(uint32_t))
 #define	PLIC_ENABLE(sc, n, h)						\
-    (sc->contexts[h].enable_offset + ((n) / 32) * sizeof(uint32_t))
+    (sc->sc_contexts[h].enable_offset + ((n) / 32) * sizeof(uint32_t))
 #define	PLIC_THRESHOLD(sc, h)						\
-    (sc->contexts[h].context_offset + PLIC_CONTEXT_THRESHOLD)
+    (sc->sc_contexts[h].context_offset + PLIC_CONTEXT_THRESHOLD)
 #define	PLIC_CLAIM(sc, h)						\
-    (sc->contexts[h].context_offset + PLIC_CONTEXT_CLAIM)
+    (sc->sc_contexts[h].context_offset + PLIC_CONTEXT_CLAIM)
 
 
 struct intrhand {
@@ -108,12 +108,15 @@ riscv_hartid_to_cpu(int hartid)
 {
 #ifdef MULTIPROCESSOR
 	// XXX Figure this out
+	panic("riscv_hartid_to_cpu unimplemented for multiprocessor");
+#if 0
 	int i;
 
 	CPU_FOREACH(i) {
 		if (pcpu_find(i)->pc_hart == hartid)
 			return (i);
 	}
+#endif
 #else
 	// XXX Figure this out
 	// Just force return CPU 0 for now
@@ -310,6 +313,14 @@ plic_attach(struct device *parent, struct device *dev, void *aux)
 	}
 
 	free(intr, M_TEMP, len);
+
+#ifdef MULTIPROCESSOR
+	panic("plic thresholds not handled for mulitprocessor");
+#else
+	// Set CPU interrupt priority thresholds to minimum
+	bus_space_write_4(plic->sc_iot, plic->sc_ioh,
+	    PLIC_THRESHOLD(sc, 0), 0);
+#endif
 
 	plic_attached = 1;
 

--- a/sys/arch/riscv64/dev/plic.c
+++ b/sys/arch/riscv64/dev/plic.c
@@ -428,12 +428,12 @@ plic_intr_establish(int irqno, int level, int (*func)(void *),
 {
 	struct plic_softc *sc = plic;
 	struct plic_intrhand *ih;
-	int psw;
+	int sie;
 
 	if (irqno < 0 || irqno >= PLIC_MAX_IRQS)
 		panic("plic_intr_establish: bogus irqnumber %d: %s",
 		     irqno, name);
-	psw = disable_interrupts();
+	sie = disable_interrupts();
 
 	ih = malloc(sizeof *ih, M_DEVBUF, M_WAITOK);
 	ih->ih_func = func;
@@ -456,7 +456,7 @@ plic_intr_establish(int irqno, int level, int (*func)(void *),
 #if 0	//XXX
 	plic_calc_mask();
 #endif
-	restore_interrupts(psw);
+	restore_interrupts(sie);
 	return (ih);
 }
 
@@ -473,14 +473,14 @@ plic_intr_disestablish(void *cookie)
 	struct plic_softc *sc = plic;
 	struct plic_intrhand *ih = cookie;
 	int irqno = ih->ih_irq;
-	int psw;
+	int sie;
 
-	psw = disable_interrupts();
+	sie = disable_interrupts();
 	TAILQ_REMOVE(&sc->sc_isrcs[irqno].is_list, ih, ih_list);
 	if (ih->ih_name != NULL)
 		evcount_detach(&ih->ih_count);
 	free(ih, M_DEVBUF, 0);
-	restore_interrupts(psw);
+	restore_interrupts(sie);
 }
 /*******************************************/
 

--- a/sys/arch/riscv64/dev/plic.c
+++ b/sys/arch/riscv64/dev/plic.c
@@ -1,51 +1,32 @@
-/*-
- * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+/*
+ * Copyright (c) 2020, Mars Li <mengshi.li.mars@gmail.com>
  *
- * Copyright (c) 2018 Ruslan Bukin <br@bsdpad.com>
- * All rights reserved.
- * Copyright (c) 2019 Mitchell Horne <mhorne@FreeBSD.org>
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
  *
- * Portions of this software were developed by SRI International and the
- * University of Cambridge Computer Laboratory (Department of Computer Science
- * and Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of
- * the DARPA SSITH research programme.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-
-#include <sys/cdefs.h>
 
 #include <sys/param.h>
 #include <sys/systm.h>
-#include <sys/kernel.h>
-#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/malloc.h>
+#include <sys/device.h>
+#include <sys/evcount.h>
 
 #include <machine/bus.h>
-#include <machine/cpu.h>
-#include <machine/intr.h>
 #include <machine/fdt.h>
 
-#include <dev/ofw/fdt.h>
 #include <dev/ofw/openfirm.h>
+#include <dev/ofw/fdt.h>
+
 
 #define	PLIC_MAX_IRQS		1024
 
@@ -68,29 +49,20 @@
     (sc->contexts[h].context_offset + PLIC_CONTEXT_CLAIM)
 
 
-#define	RD4(sc, reg)				\
-    bus_space_read_4(sc->intc_res, (reg))
-#define	WR4(sc, reg, val)			\
-    bus_space_write_4(sc->intc_res, (reg), (val))
-
-/*
- * XXX driver hooks  ====================
- */
-int	plic_match(struct device *, void *, void *);
-void	plic_attach(struct device *, struct device *, void *);
-
-int	plic_spllower(int);
-void	plic_splx(int);
-int	plic_splraise(int);
-void	plic_setipl(int);
-void	plic_irq_handler(void *);
-
-#if 0 // XXX
-struct plic_irqsrc {
-	struct intr_irqsrc	isrc;
-	u_int			irq;
+struct intrhand {
+	TAILQ_ENTRY(intrhand) ih_list;	/* link on intrq list */
+	int (*ih_func)(void *);		/* handler */
+	void *ih_arg;			/* arg for handler */
+	int ih_ipl;			/* IPL_* */
+	int ih_irq;			/* IRQ number */
+	struct evcount	ih_count;
+	char *ih_name;
 };
-#endif
+
+struct intrsource {
+	TAILQ_HEAD(, intrhand) is_list;	/* handler list */
+	int is_irq;			/* IRQ to mask while handling */
+};
 
 struct plic_context {
 	bus_size_t enable_offset;
@@ -99,25 +71,40 @@ struct plic_context {
 
 struct plic_softc {
 	struct device		sc_dev;
+	struct intrsource	sc_handler[PLIC_MAX_IRQS];
+	u_int32_t 		sc_imask[NIPL];
 	bus_space_tag_t		sc_iot;
 	bus_space_handle_t	sc_ioh;
-#if 0
-	struct resource *	intc_res;
-	struct plic_irqsrc	isrcs[PLIC_MAX_IRQS];
-#endif
-	struct plic_context	contexts[MAXCPUS];
-	int			ndev;
+	struct plic_context	sc_contexts[MAXCPUS];
+	int			sc_ndev;
+	struct interrupt_controller 	sc_intc;
 };
+struct plic_softc *plic;
+
+int	plic_match(struct device *, void *, void *);
+void	plic_attach(struct device *, struct device *, void *);
+void	plic_splx(int);
+int	plic_spllower(int);
+int	plic_splraise(int);
+void	plic_setipl(int);
+void	plic_calc_mask(void);
+void	*plic_intr_establish(int, int, int (*)(void *),
+		void *, char *);
+void	*plic_intr_establish_fdt(void *, int *, int, int (*)(void *),
+		void *, char *);
+void	plic_intr_disestablish(void *);
+void	plic_irq_handler(void *);
+void	plic_intr_route(void *, int , struct cpu_info *);
 
 struct cfattach plic_ca = {
 	sizeof(struct plic_softc), plic_match, plic_attach,
-	NULL,	// XXX need detach??
-	NULL	// XXX need activate??
 };
 
 struct cfdriver plic_cd = {
 	NULL, "plic", DV_DULL
 };
+
+int plic_attached = 0;
 
 int
 plic_match(struct device *parent, void *cfdata, void *aux)
@@ -134,49 +121,124 @@ plic_attach(struct device *parent, struct device *dev, void *aux)
 	struct plic_softc *sc = (struct plic_softc *) dev;
 	struct fdt_attach_args *faa = aux;
 
+	if (faa->fa_nreg < 1)
+		return;
+
+	plic = sc;
+
 	sc->sc_iot = faa->fa_iot;
 
-	sc->ndev = OF_getpropint(faa->fa_node, "riscv,ndev", 0);
+	/* map interrupt controller to va space */
+	if (bus_space_map(sc->sc_iot, faa->fa_reg[0].addr,
+	    faa->fa_reg[0].size, 0, &sc->sc_ioh))
+		panic("%s: bus_space_map failed!", __func__);
+
+	/* determine number of devices sending intr to this ic */
+	sc->sc_ndev = OF_getpropint(faa->fa_node, "riscv,ndev", 0);
 	if (sc->ndev >= PLIC_MAX_IRQS) {
 		printf(": invalid ndev (%d)\n", sc->ndev);
 		return;
 	}
 
-	// Request memory resources
-	if (bus_space_map(sc->sc_iot, faa->fa_reg[0].addr,
-	    faa->fa_reg[0].size, 0, &sc->sc_ioh))
-		panic("%s: bus_space_map failed!", __func__);
-
-	// XXX Register interrupt sources?
-	// XXX Disable all interrupts?
-	// XXX Clear all pending interrupts?
 
 
+	/* mask all interrupts */
+	for (i = 0; i < INTC_NUM_BANKS; i++)
+		bus_space_write_4(plic_iot, plic_ioh, INTC_MIRn(i), 0xffffffff);
 
-	/* insert self as interrupt handler */
+	for (i = 0; i < INTC_NUM_IRQ; i++) {
+		bus_space_write_4(plic_iot, plic_ioh, INTC_ILRn(i),
+		    INTC_ILR_PRIs(INTC_MIN_PRI)|INTC_ILR_IRQ);
+
+		TAILQ_INIT(&plic_handler[i].iq_list);
+	}
+
+	plic_calc_mask();
+
+	plic_attached = 1;
+
+	/*
+	 * insert self as external interrupt handler,
+	 * might need a different func call
+	 *
 	riscv_set_intr_handler(plic_splraise, plic_spllower, plic_splx,
-	    plic_setipl, plic_irq_handler);
+		plic_setipl, plic_irq_handler);
+	*/
+
+	sc->sc_intc.ic_node = faa->fa_node;
+	sc->sc_intc.ic_cookie = sc;
+	sc->sc_intc.ic_establish = plic_intr_establish_fdt;
+	sc->sc_intc.ic_disestablish = plic_intr_disestablish;
+	sc->sc_intc.ic_route = plic_intr_route;
+
+	riscv_intr_register_fdt(&sc->sc_intc);
+
+
+	plic_setipl(IPL_HIGH);  /* XXX ??? */
+
+	/* enable external interrupt */
+	// XXX
+	
+
+	// XXX Clear all pending interrupts?
 
 	return;
 }
 
-/*
- * end of driver hooks  ===============
- */
+/*******************************************/
 
+void
+plic_calc_mask(void)
+{
+	struct cpu_info *ci = curcpu();
+	struct plic_softc *sc = plic;
+	int irq;
+	struct intrhand *ih;
+	int i;
+
+	/* PLIC irq 0 is reserved, thus we start from 1 */
+	for (irq = 1; irq < PLIC_MAX_IRQS; irq++) {
+		int max = IPL_NONE;
+		int min = IPL_HIGH;
+		TAILQ_FOREACH(ih, &sc->sc_handler[irq].is_list, ih_list) {
+			if (ih->ih_ipl > max)
+				max = ih->ih_ipl;
+
+			if (ih->ih_ipl < min)
+				min = ih->ih_ipl;
+		}
+
+		sc->sc_handler[irq].iq_irq = max;
+
+		if (max == IPL_NONE)
+			min = IPL_NONE;
+
+#if 0 // DEBUG_PLIC
+		if (min != IPL_NONE) {
+			printf("irq %d to block at %d %d reg %d bit %d\n",
+			    irq, max, min, INTC_IRQ_TO_REG(irq),
+			    INTC_IRQ_TO_REGi(irq));
+		}
+#endif
+		/* Enable interrupts at lower levels, clear -> enable */
+		for (i = 1; i < min; i++)
+			plic_imask[i] &= ~(1 << (irq));// XXX
+		for (; i <= IPL_HIGH; i++)
+			plic_imask[i] |= (1 << (irq));// XXX
+	}
+	plic_setipl(ci->ci_cpl);
+}
 void
 plic_splx(int new)
 {
-#if 0
 	struct cpu_info *ci = curcpu();
 
-	if (ci->ci_ipending & arm_smask[new])
-		arm_do_pending_intr(new);
+#if 0	/* XXX how to do pending external interrupt ? */
+	if (ci->ci_ipending & arm_smask[ci->ci_cpl])
+		arm_do_pending_intr(ci->ci_cpl);// this seems to be software interrupt
+#endif
 
 	plic_setipl(new);
-#else
-	panic("plic_splx unimplemented");
-#endif
 }
 
 int
@@ -187,9 +249,6 @@ plic_spllower(int new)
 	int old = ci->ci_cpl;
 	plic_splx(new);
 	return (old);
-#else
-	panic("plic_spllower unimplemented");
-	return (new);
 #endif
 }
 
@@ -242,373 +301,112 @@ plic_setipl(int new)
 }
 
 void
+plic_intr_bootstrap(vaddr_t addr)
+{
+	int i, j;
+	extern struct bus_space armv7_bs_tag;
+	plic_iot = &armv7_bs_tag;
+	plic_ioh = addr;
+	for (i = 0; i < INTC_NUM_BANKS; i++)
+		for (j = 0; j < NIPL; j++)
+			plic_imask[i][j] = 0xffffffff;
+}
+
+void
 plic_irq_handler(void *frame)
 {
-	panic("plic_irq_handler unimplemented");
-}
-
-#if 0 // XXX till end
-static u_int plic_irq_cpu;
-
-static int
-riscv_hartid_to_cpu(int hartid)
-{
-	int i;
-
-	CPU_FOREACH(i) {
-		if (pcpu_find(i)->pc_hart == hartid)
-			return (i);
-	}
-
-	return (-1);
-}
-
-static int
-plic_get_hartid(device_t dev, phandle_t intc)
-{
-	int hart;
-
-	/* Check the interrupt controller layout. */
-	if (OF_searchencprop(intc, "#interrupt-cells", &hart,
-	    sizeof(hart)) == -1) {
-		device_printf(dev,
-		    "Could not find #interrupt-cells for phandle %u\n", intc);
-		return (-1);
-	}
-
-	/*
-	 * The parent of the interrupt-controller is the CPU we are
-	 * interested in, so search for its hart ID.
-	 */
-	if (OF_searchencprop(OF_parent(intc), "reg", (pcell_t *)&hart,
-	    sizeof(hart)) == -1) {
-		device_printf(dev, "Could not find hartid\n");
-		return (-1);
-	}
-
-	return (hart);
-}
-
-static inline void
-plic_irq_dispatch(struct plic_softc *sc, u_int irq,
-    struct trapframe *tf)
-{
-	struct plic_irqsrc *src;
-
-	src = &sc->isrcs[irq];
-
-	if (intr_isrc_dispatch(&src->isrc, tf) != 0)
-		device_printf(sc->dev, "Stray irq %u detected\n", irq);
-}
-
-static int
-plic_intr(void *arg)
-{
-	struct plic_softc *sc;
-	struct trapframe *tf;
-	uint32_t pending;
-	uint32_t cpu;
-
-	sc = arg;
-	cpu = PCPU_GET(cpuid);
-
-	pending = RD4(sc, PLIC_CLAIM(sc, cpu));
-	if (pending) {
-		tf = curthread->td_intr_frame;
-		plic_irq_dispatch(sc, pending, tf);
-		WR4(sc, PLIC_CLAIM(sc, cpu), pending);
-	}
-
-	return (FILTER_HANDLED);
-}
-
-static void
-plic_disable_intr(device_t dev, struct intr_irqsrc *isrc)
-{
-	struct plic_softc *sc;
-	struct plic_irqsrc *src;
-
-	sc = device_get_softc(dev);
-	src = (struct plic_irqsrc *)isrc;
-
-	WR4(sc, PLIC_PRIORITY(src->irq), 0);
-}
-
-static void
-plic_enable_intr(device_t dev, struct intr_irqsrc *isrc)
-{
-	struct plic_softc *sc;
-	struct plic_irqsrc *src;
-
-	sc = device_get_softc(dev);
-	src = (struct plic_irqsrc *)isrc;
-
-	WR4(sc, PLIC_PRIORITY(src->irq), 1);
-}
-
-static int
-plic_map_intr(device_t dev, struct intr_map_data *data,
-    struct intr_irqsrc **isrcp)
-{
-	struct intr_map_data_fdt *daf;
-	struct plic_softc *sc;
-
-	sc = device_get_softc(dev);
-
-	if (data->type != INTR_MAP_DATA_FDT)
-		return (ENOTSUP);
-
-	daf = (struct intr_map_data_fdt *)data;
-	if (daf->ncells != 1 || daf->cells[0] > sc->ndev)
-		return (EINVAL);
-
-	*isrcp = &sc->isrcs[daf->cells[0]].isrc;
-
-	return (0);
-}
-
-static int
-plic_probe(device_t dev)
-{
-
-	if (!ofw_bus_status_okay(dev))
-		return (ENXIO);
-
-	if (!ofw_bus_is_compatible(dev, "riscv,plic0") &&
-	    !ofw_bus_is_compatible(dev, "sifive,plic-1.0.0"))
-		return (ENXIO);
-
-	device_set_desc(dev, "RISC-V PLIC");
-
-	return (BUS_PROBE_DEFAULT);
-}
-
-static int
-plic_attach(device_t dev)
-{
-	struct plic_irqsrc *isrcs;
-	struct plic_softc *sc;
-	struct intr_pic *pic;
-	pcell_t *cells;
-	uint32_t irq;
-	const char *name;
-	phandle_t node;
-	phandle_t xref;
-	uint32_t cpu;
-	int error;
-	int rid;
-	int nintr;
-	int context;
-	int i;
-	int hart;
-
-	sc = device_get_softc(dev);
-
-	sc->dev = dev;
-
-	node = ofw_bus_get_node(dev);
-	if ((OF_getencprop(node, "riscv,ndev", &sc->ndev,
-	    sizeof(sc->ndev))) < 0) {
-		device_printf(dev,
-		    "Error: could not get number of devices\n");
-		return (ENXIO);
-	}
-
-	if (sc->ndev >= PLIC_MAX_IRQS) {
-		device_printf(dev,
-		    "Error: invalid ndev (%d)\n", sc->ndev);
-		return (ENXIO);
-	}
-
-	/* Request memory resources */
-	rid = 0;
-	sc->intc_res = bus_alloc_resource_any(dev, SYS_RES_MEMORY, &rid,
-	    RF_ACTIVE);
-	if (sc->intc_res == NULL) {
-		device_printf(dev,
-		    "Error: could not allocate memory resources\n");
-		return (ENXIO);
-	}
-
-	/* Register the interrupt sources */
-	isrcs = sc->isrcs;
-	name = device_get_nameunit(sc->dev);
-	for (irq = 1; irq <= sc->ndev; irq++) {
-		isrcs[irq].irq = irq;
-		error = intr_isrc_register(&isrcs[irq].isrc, sc->dev,
-		    0, "%s,%u", name, irq);
-		if (error != 0)
-			return (error);
-
-		WR4(sc, PLIC_PRIORITY(irq), 0);
-	}
-
-	/*
-	 * Calculate the per-cpu enable and context register offsets.
-	 *
-	 * This is tricky for a few reasons. The PLIC divides the interrupt
-	 * enable, threshold, and claim bits by "context", where each context
-	 * routes to a Core-Local Interrupt Controller (CLIC).
-	 *
-	 * The tricky part is that the PLIC spec imposes no restrictions on how
-	 * these contexts are laid out. So for example, there is no guarantee
-	 * that each CPU will have both a machine mode and supervisor context,
-	 * or that different PLIC implementations will organize the context
-	 * registers in the same way. On top of this, we must handle the fact
-	 * that cpuid != hartid, as they may have been renumbered during boot.
-	 * We perform the following steps:
-	 *
-	 * 1. Examine the PLIC's "interrupts-extended" property and skip any
-	 *    entries that are not for supervisor external interrupts.
-	 *
-	 * 2. Walk up the device tree to find the corresponding CPU, and grab
-	 *    it's hart ID.
-	 *
-	 * 3. Convert the hart to a cpuid, and calculate the register offsets
-	 *    based on the context number.
-	 */
-	nintr = OF_getencprop_alloc_multi(node, "interrupts-extended",
-	    sizeof(uint32_t), (void **)&cells);
-	if (nintr <= 0) {
-		device_printf(dev, "Could not read interrupts-extended\n");
-		return (ENXIO);
-	}
-
-	/* interrupts-extended is a list of phandles and interrupt types. */
-	for (i = 0, context = 0; i < nintr; i += 2, context++) {
-		/* Skip M-mode external interrupts */
-		if (cells[i + 1] != IRQ_EXTERNAL_SUPERVISOR)
-			continue;
-
-		/* Get the hart ID from the CLIC's phandle. */
-		hart = plic_get_hartid(dev, OF_node_from_xref(cells[i]));
-		if (hart < 0) {
-			OF_prop_free(cells);
-			return (ENXIO);
-		}
-
-		/* Get the corresponding cpuid. */
-		cpu = riscv_hartid_to_cpu(hart);
-		if (cpu < 0) {
-			device_printf(dev, "Invalid hart!\n");
-			OF_prop_free(cells);
-			return (ENXIO);
-		}
-
-		/* Set the enable and context register offsets for the CPU. */
-		sc->contexts[cpu].enable_offset = PLIC_ENABLE_BASE +
-		    context * PLIC_ENABLE_STRIDE;
-		sc->contexts[cpu].context_offset = PLIC_CONTEXT_BASE +
-		    context * PLIC_CONTEXT_STRIDE;
-	}
-	OF_prop_free(cells);
-
-	/* Set the threshold for each CPU to accept all priorities. */
-	CPU_FOREACH(cpu)
-		WR4(sc, PLIC_THRESHOLD(sc, cpu), 0);
-
-	xref = OF_xref_from_node(node);
-	pic = intr_pic_register(sc->dev, xref);
-	if (pic == NULL)
-		return (ENXIO);
-
-	csr_set(sie, SIE_SEIE);
-
-	return (intr_pic_claim_root(sc->dev, xref, plic_intr, sc, 0));
-}
-
-static void
-plic_pre_ithread(device_t dev, struct intr_irqsrc *isrc)
-{
-
-	plic_disable_intr(dev, isrc);
-}
-
-static void
-plic_post_ithread(device_t dev, struct intr_irqsrc *isrc)
-{
-
-	plic_enable_intr(dev, isrc);
-}
-
-static int
-plic_setup_intr(device_t dev, struct intr_irqsrc *isrc,
-    struct resource *res, struct intr_map_data *data)
-{
-	struct plic_softc *sc;
-	struct plic_irqsrc *src;
-
-	sc = device_get_softc(dev);
-	src = (struct plic_irqsrc *)isrc;
-
-	/* Bind to the boot CPU for now. */
-	CPU_SET(PCPU_GET(cpuid), &isrc->isrc_cpu);
-	plic_bind_intr(dev, isrc);
-
-	return (0);
-}
-
-static int
-plic_bind_intr(device_t dev, struct intr_irqsrc *isrc)
-{
-	struct plic_softc *sc;
-	struct plic_irqsrc *src;
-	uint32_t reg;
-	u_int cpu;
-
-	sc = device_get_softc(dev);
-	src = (struct plic_irqsrc *)isrc;
-
-	/* Disable the interrupt source on all CPUs. */
-	CPU_FOREACH(cpu) {
-		reg = RD4(sc, PLIC_ENABLE(sc, src->irq, cpu));
-		reg &= ~(1 << (src->irq % 32));
-		WR4(sc, PLIC_ENABLE(sc, src->irq, cpu), reg);
-	}
-
-	if (CPU_EMPTY(&isrc->isrc_cpu)) {
-		cpu = plic_irq_cpu = intr_irq_next_cpu(plic_irq_cpu, &all_cpus);
-		CPU_SETOF(cpu, &isrc->isrc_cpu);
-	} else {
-		/*
-		 * We will only bind to a single CPU so select the first
-		 * CPU found.
-		 */
-		cpu = CPU_FFS(&isrc->isrc_cpu) - 1;
-	}
-
-	/* Enable the interrupt on the selected CPU only. */
-	reg = RD4(sc, PLIC_ENABLE(sc, src->irq, cpu));
-	reg |= (1 << (src->irq % 32));
-	WR4(sc, PLIC_ENABLE(sc, src->irq, cpu), reg);
-
-	return (0);
-}
-
-static device_method_t plic_methods[] = {
-	DEVMETHOD(device_probe,		plic_probe),
-	DEVMETHOD(device_attach,	plic_attach),
-
-	DEVMETHOD(pic_disable_intr,	plic_disable_intr),
-	DEVMETHOD(pic_enable_intr,	plic_enable_intr),
-	DEVMETHOD(pic_map_intr,		plic_map_intr),
-	DEVMETHOD(pic_pre_ithread,	plic_pre_ithread),
-	DEVMETHOD(pic_post_ithread,	plic_post_ithread),
-	DEVMETHOD(pic_setup_intr,	plic_setup_intr),
-	DEVMETHOD(pic_bind_intr,	plic_bind_intr),
-
-	DEVMETHOD_END
-};
-
-static driver_t plic_driver = {
-	"plic",
-	plic_methods,
-	sizeof(struct plic_softc),
-};
-
-static devclass_t plic_devclass;
-
-EARLY_DRIVER_MODULE(plic, simplebus, plic_driver, plic_devclass,
-    0, 0, BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
-
+#if 0
+	int irq, pri, s;
+	struct intrhand *ih;
+	void *arg;
+
+	irq = bus_space_read_4(plic_iot, plic_ioh, INTC_SIR_IRQ);
+#ifdef DEBUG_INTC
+	printf("irq %d fired\n", irq);
 #endif
+
+	pri = plic_handler[irq].iq_irq;
+	s = plic_splraise(pri);
+	TAILQ_FOREACH(ih, &plic_handler[irq].iq_list, ih_list) {
+		if (ih->ih_arg != 0)
+			arg = ih->ih_arg;
+		else
+			arg = frame;
+
+		if (ih->ih_func(arg))
+			ih->ih_count.ec_count++;
+
+	}
+	bus_space_write_4(plic_iot, plic_ioh, INTC_CONTROL,
+	    INTC_CONTROL_NEWIRQ);
+
+	plic_splx(s);
+#else
+	panic("plic_irq_handler unimplemented");
+#endif
+}
+
+void *
+plic_intr_establish(int irqno, int level, int (*func)(void *),
+    void *arg, char *name)
+{
+	struct plic_softc *sc = plic;
+	struct intrhand *ih;
+	int psw;
+
+	if (irqno < 0 || irqno >= INTC_NIRQ)
+		panic("plic_intr_establish: bogus irqnumber %d: %s",
+		     irqno, name);
+	psw = disable_interrupts();
+
+	ih = malloc(sizeof *ih, M_DEVBUF, M_WAITOK);
+	ih->ih_func = func;
+	ih->ih_arg = arg;
+	ih->ih_ipl = level & IPL_IRQMASK;
+	ih->ih_flags = level & IPL_FLAGMASK;//XXX flags for ?
+	ih->ih_irq = irqno;
+	ih->ih_name = name;
+
+#if 0	// XXX
+	if (IS_IRQ_LOCAL(irqno))
+		sc->sc_localcoremask[0] |= (1 << IRQ_LOCAL(irqno));
+#endif
+
+	TAILQ_INSERT_TAIL(&sc->sc_handler[irqno].is_list, ih, ih_list);
+
+	if (name != NULL)
+		evcount_attach(&ih->ih_count, name, &ih->ih_irq);
+
+#ifdef DEBUG_INTC
+	printf("%s irq %d level %d [%s]\n", __func__, irqno, level,
+	    name);
+#endif
+#if 0	//XXX
+	plic_calc_mask();
+#endif
+	restore_interrupts(psw);
+	return (ih);
+}
+
+void *
+plic_intr_establish_fdt(void *cookie, int *cell, int level,
+    int (*func)(void *), void *arg, char *name)
+{
+	return plic_intr_establish(cell[0], level, func, arg, name);
+}
+
+void
+plic_intr_disestablish(void *cookie)
+{
+	struct plic_softc *sc = plic;
+	struct intrhand *ih = cookie;
+	int irqno = ih->ih_irq;
+	int psw;
+
+	psw = disable_interrupts();
+	TAILQ_REMOVE(&sc->sc_handler[irqno].is_list, ih, ih_list);
+	if (ih->ih_name != NULL)
+		evcount_detach(&ih->ih_count);
+	free(ih, M_DEVBUF, 0);
+	restore_interrupts(psw);
+}

--- a/sys/arch/riscv64/dev/plic.h
+++ b/sys/arch/riscv64/dev/plic.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Mars Li <mengshi.li.mars@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _RISCV_PLIC_H_
+#define _RISCV_PLIC_H_
+
+#ifndef _LOCORE
+
+#if 0
+#include <arm/armreg.h>
+#include <arm/cpufunc.h>
+#include <machine/intr.h>
+#include <arm/softintr.h>
+#endif
+
+extern volatile int current_spl_level;
+extern volatile int softint_pending;
+void intc_do_pending(void);
+
+#define SI_TO_IRQBIT(si)  (1U<<(si))
+void intc_setipl(int new);
+void intc_splx(int new);
+int intc_splraise(int ipl);
+int intc_spllower(int ipl);
+void intc_setsoftintr(int si);
+
+/*
+ * An useful function for interrupt handlers.
+ * XXX: This shouldn't be here.
+ */
+static __inline int
+find_first_bit( uint32_t bits )
+{
+	int count;
+
+	/* since CLZ is available only on ARMv5, this isn't portable
+	 * to all ARM CPUs.  This file is for OMAPINTC processor.
+	 */
+	asm( "clz %0, %1" : "=r" (count) : "r" (bits) );
+	return 31-count;
+}
+
+
+/*
+ * This function *MUST* be called very early on in a port's
+ * initarm() function, before ANY spl*() functions are called.
+ *
+ * The parameter is the virtual address of the OMAPINTC's Interrupt
+ * Controller registers.
+ */
+void intc_intr_bootstrap(vaddr_t);
+
+void intc_irq_handler(void *);
+void *intc_intr_establish(int irqno, int level, int (*func)(void *),
+    void *cookie, char *name);
+void intc_intr_disestablish(void *cookie);
+const char *intc_intr_string(void *cookie);
+
+#endif /* ! _LOCORE */
+
+#endif /* _RISCV_PLIC_H_*/

--- a/sys/arch/riscv64/dev/plic.h
+++ b/sys/arch/riscv64/dev/plic.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Mars Li <mengshi.li.mars@gmail.com>
+ * Copyright (c) 2020, Brian Bamsch <bbamsch@google.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -20,23 +21,24 @@
 #ifndef _LOCORE
 
 #if 0
-#include <arm/armreg.h>
-#include <arm/cpufunc.h>
+#include <machine/riscvreg.h>
+#include <machine/cpufunc.h>
 #include <machine/intr.h>
 #include <arm/softintr.h>
 #endif
 
 extern volatile int current_spl_level;
 extern volatile int softint_pending;
-void intc_do_pending(void);
+void plic_do_pending(void);
 
 #define SI_TO_IRQBIT(si)  (1U<<(si))
-void intc_setipl(int new);
-void intc_splx(int new);
-int intc_splraise(int ipl);
-int intc_spllower(int ipl);
-void intc_setsoftintr(int si);
+void plic_setipl(int new);
+void plic_splx(int new);
+int plic_splraise(int ipl);
+int plic_spllower(int ipl);
+void plic_setsoftintr(int si);
 
+#if 0
 /*
  * An useful function for interrupt handlers.
  * XXX: This shouldn't be here.
@@ -52,22 +54,23 @@ find_first_bit( uint32_t bits )
 	asm( "clz %0, %1" : "=r" (count) : "r" (bits) );
 	return 31-count;
 }
+#endif
 
 
 /*
  * This function *MUST* be called very early on in a port's
- * initarm() function, before ANY spl*() functions are called.
+ * initriscv() function, before ANY spl*() functions are called.
  *
- * The parameter is the virtual address of the OMAPINTC's Interrupt
+ * The parameter is the virtual address of the RISC-V Platform Interrupt
  * Controller registers.
  */
-void intc_intr_bootstrap(vaddr_t);
+void plic_intr_bootstrap(vaddr_t);
 
-void intc_irq_handler(void *);
-void *intc_intr_establish(int irqno, int level, int (*func)(void *),
+void plic_irq_handler(void *);
+void *plic_intr_establish(int irqno, int level, int (*func)(void *),
     void *cookie, char *name);
-void intc_intr_disestablish(void *cookie);
-const char *intc_intr_string(void *cookie);
+void plic_intr_disestablish(void *cookie);
+const char *plic_intr_string(void *cookie);
 
 #endif /* ! _LOCORE */
 

--- a/sys/arch/riscv64/dev/riscv_cpu_intc.c
+++ b/sys/arch/riscv64/dev/riscv_cpu_intc.c
@@ -81,6 +81,38 @@ riscv_intc_attach(struct device *parent, struct device *self, void *aux)
 	enable_interrupts();
 }
 
+/******** overall spl* routine ********/
+void
+riscv_intc_calc_mask(void)
+{
+
+}
+
+void
+riscv_intc_splx(int new)
+{
+	struct cpu_info *ci = curcpu();
+
+	if (ci->ci_ipending & riscv_smask[new])
+		riscv_do_pending_intr(new);
+
+	riscv_intc_setipl(new);
+
+	/* deliver newx to plic too ?? */
+	plic_splx(new);
+}
+
+int
+riscv_intc_spllower(int new)
+{
+	struct cpu_info *ci = curcpu();
+	int old = ci->ci_cpl;
+	riscv_intc_splx(new);
+	return (old);
+}
+
+
+/* global interrupt handler */
 void
 riscv_intc_irq_handler(void *frame)
 {

--- a/sys/arch/riscv64/dev/riscv_cpu_intc.c
+++ b/sys/arch/riscv64/dev/riscv_cpu_intc.c
@@ -96,10 +96,12 @@ riscv_intc_splx(int new)
 	if (ci->ci_ipending & riscv_smask[new])
 		riscv_do_pending_intr(new);
 
-	riscv_intc_setipl(new);
+	panic("riscv_intr_splx unfinished");
+	// XXX undefined?
+	// riscv_intc_setipl(new);
 
-	/* deliver newx to plic too ?? */
-	plic_splx(new);
+	// XXX deliver newx to plic too ??
+	// plic_splx(new);
 }
 
 int

--- a/sys/arch/riscv64/dev/riscv_cpu_intc.c
+++ b/sys/arch/riscv64/dev/riscv_cpu_intc.c
@@ -140,13 +140,13 @@ void *
 riscv_intc_intr_establish(int irqno, int dummy_level, int (*func)(void *),
     void *arg, char *name)
 {
-	int psw;
+	int sie;
 	struct intrhand *ih;
 
 	if (irqno < 0 || irqno >= INTC_NIRQS)
 		panic("intc_intr_establish: bogus irqnumber %d: %s",
 		     irqno, name);
-	psw = disable_interrupts();
+	sie = disable_interrupts();
 
 	ih = malloc(sizeof(*ih), M_DEVBUF, M_WAITOK);
 	ih->ih_func = func;
@@ -158,20 +158,20 @@ riscv_intc_intr_establish(int irqno, int dummy_level, int (*func)(void *),
 #ifdef DEBUG_INTC
 	printf("intc_intr_establish irq %d [%s]\n", irqno, name);
 #endif
-	restore_interrupts(psw);
+	restore_interrupts(sie);
 	return (ih);
 }
 
 void
 riscv_intc_intr_disestablish(void *cookie)
 {
-	int psw;
+	int sie;
 	struct intrhand *ih = cookie;
 	int irqno = ih->ih_irq;
-	psw = disable_interrupts();
+	sie = disable_interrupts();
 
 	intc_handler[irqno] = NULL;
 	free(ih, M_DEVBUF, 0);
 
-	restore_interrupts(psw);
+	restore_interrupts(sie);
 }

--- a/sys/arch/riscv64/dev/riscv_cpu_intc.c
+++ b/sys/arch/riscv64/dev/riscv_cpu_intc.c
@@ -132,7 +132,7 @@ riscv_intc_irq_handler(void *frame)
 #endif
 
 	ih = intc_handler[irq];
-	if (ih->ih_func(frame))
+	if (ih->ih_func(frame) == 0)
 		printf("fail in handleing irq %d\n", irq);
 }
 

--- a/sys/arch/riscv64/dev/timer.c
+++ b/sys/arch/riscv64/dev/timer.c
@@ -204,7 +204,7 @@ riscv_timer_attach(struct device *parent, struct device *self, void *aux)
 }
 
 int
-riscv_timer_intr(void *arg)
+riscv_timer_intr(void *frame)
 {
 	struct riscv_timer_softc *sc;
 	uint64_t next;
@@ -213,17 +213,12 @@ riscv_timer_intr(void *arg)
 #ifdef	DEBUG_TIMER
 	printf("RISC-V Timer Interrupt\n");
 #endif
-	sc = (struct riscv_timer_softc *)arg;
+	sc = riscv_timer_sc;
 
 	next = get_cycles() + sc->sc_ticks_per_second / new_hz;
 	sbi_set_timer(next);
 
 	csr_clear(sip, SIP_STIP);
-
-#if 0	// Not relevant? FreeBSD specific?
-	if (sc->et.et_active)
-		sc->et.et_event_cb(&sc->et, sc->et.et_arg);
-#endif
 
 	return (0); // Handled
 }

--- a/sys/arch/riscv64/dev/timer.c
+++ b/sys/arch/riscv64/dev/timer.c
@@ -220,7 +220,7 @@ riscv_timer_intr(void *frame)
 
 	csr_clear(sip, SIP_STIP);
 
-	return (0); // Handled
+	return (1); // Handled
 }
 
 void

--- a/sys/arch/riscv64/dev/timer.c
+++ b/sys/arch/riscv64/dev/timer.c
@@ -208,7 +208,7 @@ riscv_timer_intr(void *arg)
 {
 	struct riscv_timer_softc *sc;
 	uint64_t next;
-	u_int new_hz = 1000;
+	u_int new_hz = 100;
 
 #ifdef	DEBUG_TIMER
 	printf("RISC-V Timer Interrupt\n");

--- a/sys/arch/riscv64/include/cpu.h
+++ b/sys/arch/riscv64/include/cpu.h
@@ -148,10 +148,12 @@ curcpu(void)
 	return (__ci);
 }
 
+extern uint32_t boot_hart;	/* The hart we booted on. */
 extern struct cpu_info cpu_info_primary;
 extern struct cpu_info *cpu_info_list;
 
 #ifndef MULTIPROCESSOR
+
 #define cpu_number()	0
 #define CPU_IS_PRIMARY(ci)	1
 #define CPU_INFO_ITERATOR	int
@@ -160,7 +162,9 @@ extern struct cpu_info *cpu_info_list;
 #define CPU_INFO_UNIT(ci)	0
 #define MAXCPUS	1
 #define cpu_unidle(ci)
+
 #else
+
 #define cpu_number()		(curcpu()->ci_cpuid)
 #define CPU_IS_PRIMARY(ci)	((ci) == &cpu_info_primary)
 #define CPU_INFO_ITERATOR		int

--- a/sys/arch/riscv64/include/db_machdep.h
+++ b/sys/arch/riscv64/include/db_machdep.h
@@ -77,6 +77,7 @@ extern db_regs_t	ddb_regs;
 
 #define SOFTWARE_SSTEP
 
+void db_machine_init (void);
 db_addr_t db_branch_taken(u_int inst, db_addr_t pc, db_regs_t *regs);
 
 #define branch_taken(ins, pc, fun, regs) \

--- a/sys/arch/riscv64/include/intr.h
+++ b/sys/arch/riscv64/include/intr.h
@@ -175,7 +175,7 @@ restore_interrupts(uint64_t s)
 {
 	__asm volatile(
 		"csrs sstatus, %0"
-		:: "r" (s)
+		:: "r" (s & (SSTATUS_SIE))
 	);
 }
 

--- a/sys/arch/riscv64/riscv64/cpuswitch.S
+++ b/sys/arch/riscv64/riscv64/cpuswitch.S
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Dale Rahn <drahn@dalerahn.com>
+ * Copyright (c) 2020 Brian Bamsch <bbamsch@google.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/sys/arch/riscv64/riscv64/cpuswitch.S
+++ b/sys/arch/riscv64/riscv64/cpuswitch.S
@@ -17,127 +17,77 @@
 #include "machine/asm.h"
 #include "assym.h"
 
-//from freebsd/riscv/swtch.S
 /*
- * void cpu_switch(struct thread *old, struct thread *new, struct mtx *mtx)
- *
- * a0 = old
- * a1 = new
- * a2 = mtx
- * x3 to x7, x16 and x17 are caller saved
-*/
-
+ * cpu_switchto(struct proc *oldproc, struct proc *newproc)
+ *      a0	'struct proc *' of the old context
+ *      a1	'struct proc *' of the new context
+ */
 ENTRY(cpu_switchto)
+	// check if old context needs to be saved
+	beqz	a0, 1f
 
-//XXX TODO:
-#if 0
-	/* Store the new curthread */
-	sd	a1, PC_CURTHREAD(tp)
-	/* And the new pcb */
-	ld	x13, TD_PCB(a1)
-	sd	x13, PC_CURPCB(tp)
+	// create switchframe
+	addi	sp, sp, -SWITCHFRAME_SIZEOF
+	sd	s0, (SF_S + 0 * 8)(sp)
+	sd	s1, (SF_S + 1 * 8)(sp)
+	sd	s2, (SF_S + 2 * 8)(sp)
+	sd	s3, (SF_S + 3 * 8)(sp)
+	sd	s4, (SF_S + 4 * 8)(sp)
+	sd	s5, (SF_S + 5 * 8)(sp)
+	sd	s6, (SF_S + 6 * 8)(sp)
+	sd	s7, (SF_S + 7 * 8)(sp)
+	sd	s8, (SF_S + 8 * 8)(sp)
+	sd	s9, (SF_S + 9 * 8)(sp)
+	sd	s10, (SF_S + 10 * 8)(sp)
+	sd	s11, (SF_S + 11 * 8)(sp)
 
-	/* Save the old context. */
-	ld	x13, TD_PCB(a0)
+	// store switchframe
+	ld	a5, CI_CURPCB(tp)
+	sd	sp, PCB_SP(a5)
+	// XXX do we need to save return address?
 
-	/* Store ra, sp and the callee-saved registers */
-	sd	ra, (PCB_RA)(x13)
-	sd	sp, (PCB_SP)(x13)
+	// XXX store fpu, if necessary
 
-	/* s[0-11] */
-	sd	s0, (PCB_S + 0 * 8)(x13)
-	sd	s1, (PCB_S + 1 * 8)(x13)
-	sd	s2, (PCB_S + 2 * 8)(x13)
-	sd	s3, (PCB_S + 3 * 8)(x13)
-	sd	s4, (PCB_S + 4 * 8)(x13)
-	sd	s5, (PCB_S + 5 * 8)(x13)
-	sd	s6, (PCB_S + 6 * 8)(x13)
-	sd	s7, (PCB_S + 7 * 8)(x13)
-	sd	s8, (PCB_S + 8 * 8)(x13)
-	sd	s9, (PCB_S + 9 * 8)(x13)
-	sd	s10, (PCB_S + 10 * 8)(x13)
-	sd	s11, (PCB_S + 11 * 8)(x13)
-
-#ifdef FPE
-	/*
-	 * Is FPE enabled and is it in dirty state
-	 * for the old thread?
-	 */
-	ld	t0, TD_FRAME(a0)
-	ld	t1, (TF_SSTATUS)(t0)
-	li	t2, SSTATUS_FS_MASK
-	and	t3, t1, t2
-	li	t2, SSTATUS_FS_DIRTY
-	bne	t3, t2, 1f		/* No, skip. */
-
-	/* Yes, mark FPE state clean and save registers. */
-	li	t2, ~SSTATUS_FS_MASK
-	and	t3, t1, t2
-	li	t2, SSTATUS_FS_CLEAN
-	or	t3, t3, t2
-	sd	t3, (TF_SSTATUS)(t0)
-
-	__fpe_state_save x13
 1:
-#endif
+	RETGUARD_SYMBOL(cpu_switchto)
+	RETGUARD_LOAD_RANDOM(cpu_switchto, s0)
 
-	/* Activate the new thread's pmap */
-	mv	s0, a0
-	mv	s1, a1
-	mv	s2, a2
+	li	a5, SONPROC
+	sb	a5, P_STAT(a1)		// Mark new on cpu
+	sd	tp, P_CPU(a1)		// Store curcpu
+	ld	a5, P_ADDR(a1)		// Load new pcb
+	sd	a5, CI_CURPCB(tp)
+	sd	a1, CI_CURPROC(tp)
+
+	// Unlike AArch64, RISC-V does not have a dedicated register in which
+	// we can also store pcb_tcb. Supervisor must access tcb indirectly.
+
+	ld	s1, PCB_SP(a5)		// load new stack pointer
 	mv	a0, a1
-	call	_C_LABEL(pmap_activate_sw)
-	mv	a1, s1
+	la	t0, pmap_set_satp
+	jalr	t0
 
-	/* Release the old thread */
-	sd	s2, TD_LOCK(s0)
-#if defined(SCHED_ULE) && defined(SMP)
-	/* Spin if TD_LOCK points to a blocked_lock */
-	la	s2, _C_LABEL(blocked_lock)
-1:
-	ld	t0, TD_LOCK(a1)
-	beq	t0, s2, 1b
-#endif
-	/*
-	 * Restore the saved context.
-	 */
-	ld	x13, TD_PCB(a1)
+	mv	a7, s0			// move retguard random
+	mv	sp, s1			// restore stack pointer
 
-	/* Restore the registers */
-	ld	ra, (PCB_RA)(x13)
-	ld	sp, (PCB_SP)(x13)
+	ld	s0, (SF_S + 0 * 8)(sp)
+	ld	s1, (SF_S + 1 * 8)(sp)
+	ld	s2, (SF_S + 2 * 8)(sp)
+	ld	s3, (SF_S + 3 * 8)(sp)
+	ld	s4, (SF_S + 4 * 8)(sp)
+	ld	s5, (SF_S + 5 * 8)(sp)
+	ld	s6, (SF_S + 6 * 8)(sp)
+	ld	s7, (SF_S + 7 * 8)(sp)
+	ld	s8, (SF_S + 8 * 8)(sp)
+	ld	s9, (SF_S + 9 * 8)(sp)
+	ld	s10, (SF_S + 10 * 8)(sp)
+	ld	s11, (SF_S + 11 * 8)(sp)
 
-	/* s[0-11] */
-	ld	s0, (PCB_S + 0 * 8)(x13)
-	ld	s1, (PCB_S + 1 * 8)(x13)
-	ld	s2, (PCB_S + 2 * 8)(x13)
-	ld	s3, (PCB_S + 3 * 8)(x13)
-	ld	s4, (PCB_S + 4 * 8)(x13)
-	ld	s5, (PCB_S + 5 * 8)(x13)
-	ld	s6, (PCB_S + 6 * 8)(x13)
-	ld	s7, (PCB_S + 7 * 8)(x13)
-	ld	s8, (PCB_S + 8 * 8)(x13)
-	ld	s9, (PCB_S + 9 * 8)(x13)
-	ld	s10, (PCB_S + 10 * 8)(x13)
-	ld	s11, (PCB_S + 11 * 8)(x13)
+	// XXX restore fpu, if necessary
 
-#ifdef FPE
-	/* Is FPE enabled for new thread? */
-	ld	t0, TD_FRAME(a1)
-	ld	t1, (TF_SSTATUS)(t0)
-	li	t2, SSTATUS_FS_MASK
-	and	t3, t1, t2
-	beqz	t3, 1f		/* No, skip. */
-
-	/* Restore registers. */
-	__fpe_state_load x13
-1:
-#endif
-
+	RETGUARD_CALC_COOKIE(a7)
+	addi	sp, sp, SWITCHFRAME_SIZEOF
+	RETGUARD_CHECK(cpu_switchto, a7)
 	ret
-.Lcpu_switch_panic_str:
-	.asciz "cpu_switch: %p\0"
-
-#endif
 END(cpu_switch)
 

--- a/sys/arch/riscv64/riscv64/genassym.cf
+++ b/sys/arch/riscv64/riscv64/genassym.cf
@@ -25,16 +25,24 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
+include <sys/param.h>
+include <sys/proc.h>
+include <sys/systm.h>
+include <sys/mbuf.h>
+include <sys/resourcevar.h>
+include <sys/device.h>
+include <sys/user.h>
+include <sys/signal.h>
+include <sys/mbuf.h>
+include <sys/socketvar.h>
+include <netinet/in.h>
+include <netinet/ip.h>
+
 include <machine/frame.h>
 include <machine/pcb.h>
 include <machine/cpu.h>
 include <machine/param.h>
 include <machine/bootconfig.h>
-
-#export	PAGE_SIZE
-#export	VM_MAXUSER_ADDRESS
-#export	VM_MIN_KERNEL_ADDRESS
-#export	SSTATUS_SUM
 
 struct	trapframe
 member	tf_ra
@@ -48,6 +56,16 @@ member	tf_sepc
 member	tf_sstatus
 member	tf_stval
 member	tf_scause
+
+struct	switchframe
+member	sf_s
+
+struct	proc
+member	p_stat
+member	p_cpu
+member	p_addr
+
+export	SONPROC
 
 struct	sigframe
 member	sf_signum

--- a/sys/arch/riscv64/riscv64/intr.c
+++ b/sys/arch/riscv64/riscv64/intr.c
@@ -403,18 +403,18 @@ void
 riscv_do_pending_intr(int pcpl)
 {
 	struct cpu_info *ci = curcpu();
-	int oldirqstate;
+	int sie;
 
-	oldirqstate = disable_interrupts();
+	sie = disable_interrupts();
 
 #define DO_SOFTINT(si, ipl) \
 	if ((ci->ci_ipending & riscv_smask[pcpl]) &	\
 	    SI_TO_IRQBIT(si)) {						\
 		ci->ci_ipending &= ~SI_TO_IRQBIT(si);			\
 		riscv_intr_func.setipl(ipl);				\
-		restore_interrupts(oldirqstate);			\
+		restore_interrupts(sie);			\
 		softintr_dispatch(si);					\
-		oldirqstate = disable_interrupts();			\
+		sie = disable_interrupts();			\
 	}
 
 	do {
@@ -426,7 +426,7 @@ riscv_do_pending_intr(int pcpl)
 
 	/* Don't use splx... we are here already! */
 	riscv_intr_func.setipl(pcpl);
-	restore_interrupts(oldirqstate);
+	restore_interrupts(sie);
 }
 
 void riscv_set_intr_handler(int (*raise)(int), int (*lower)(int),

--- a/sys/arch/riscv64/riscv64/locore.S
+++ b/sys/arch/riscv64/riscv64/locore.S
@@ -244,11 +244,9 @@ va:					//XXX just a trampoline?
 	addi	s0, s0, 8
 	bltu	s0, s1, 1b
 
-#ifdef SMP			//Symmetric Multiprocessing, XXX defined in /config/GENERIC?
 	/* Store boot hart id. */
 	la	t0, boot_hart	//defined in machdep.c, the hart we booted on.
 	sw	a0, 0(t0)	//all above logic runs on this a0 hart.
-#endif
 
 	/* Fill riscv_bootparams */
 	addi	sp, sp, -RISCV_BOOTPARAMS_SIZEOF
@@ -338,7 +336,7 @@ hart_lottery:
 init_pt_va:
 	.quad pagetable_l2	/* XXX: Keep page tables VA */
 
-#ifndef SMP
+#ifndef MULTIPROCESSOR
 ENTRY(mpentry)
 1:
 	wfi

--- a/sys/arch/riscv64/riscv64/machdep.c
+++ b/sys/arch/riscv64/riscv64/machdep.c
@@ -90,6 +90,7 @@ extern todr_chip_handle_t todr_handle;
 
 int safepri = 0;
 
+uint32_t boot_hart;	/* The hart we booted on. */
 struct cpu_info cpu_info_primary;
 struct cpu_info *cpu_info[MAXCPUS] = { &cpu_info_primary };
 

--- a/sys/arch/riscv64/riscv64/pmap.c
+++ b/sys/arch/riscv64/riscv64/pmap.c
@@ -1475,15 +1475,15 @@ void
 pmap_activate(struct proc *p)
 {
 	pmap_t pm = p->p_vmspace->vm_map.pmap;
-	int psw;
+	int sie;
 
-	psw = disable_interrupts();
+	sie = disable_interrupts();
 	if (p == curproc && pm != curcpu()->ci_curpm) {
 		load_satp(SATP_MODE(pm->pm_mode) | SATP_ASID(pm->pm_asid) |
 				SATP_PPN(pm->pm_pt0pa >> PAGE_SHIFT));
 		curcpu()->ci_curpm = pm;
 	}
-	restore_interrupts(psw);
+	restore_interrupts(sie);
 }
 
 /*


### PR DESCRIPTION
Implementation work for the RISC-V Platform Interrupt Controller and CPU Context Switch.
CPU Context switch during shutdown doesn't work yet as proc0 mappings do not carry over in fork to proc1 yet. This needs further investigation.