### PR TITLE
Nicen up db_* files a little

### DIFF
--- a/sys/arch/riscv64/riscv64/db_disasm.c
+++ b/sys/arch/riscv64/riscv64/db_disasm.c
@@ -461,6 +461,6 @@ db_disasm(vaddr_t loc, int altfmt)
 	 * list, pretend it's a compressed instruction then (for now)
 	 */
 
-	db_printf("a compressed instruction?!!\n");
+	db_printf("[not displaying compressed instruction]\n");
 	return loc + 2;
 }

--- a/sys/arch/riscv64/riscv64/db_interface.c
+++ b/sys/arch/riscv64/riscv64/db_interface.c
@@ -125,13 +125,18 @@ kdb_trap(int type, db_regs_t *regs)
 }
 #endif
 
+#define INKERNEL(va)    (((vaddr_t)(va)) & (1ULL << 63))
+
+static int db_validate_address(vaddr_t addr);
+
 static int
 db_validate_address(vaddr_t addr)
 {
 	struct proc *p = curproc;
 	struct pmap *pmap;
 
-	if (!p || !p->p_vmspace || !p->p_vmspace->vm_map.pmap)
+	if (!p || !p->p_vmspace || !p->p_vmspace->vm_map.pmap ||
+		INKERNEL(addr))
 		pmap = pmap_kernel();
 	else
 		pmap = p->p_vmspace->vm_map.pmap;


### PR DESCRIPTION
I have nicened the output when the kernel encounters a compressed instruction in an entry to ddb, before it was meh, now it should look better and more informative.
Also I have added back an INKERNEL() macro that I initially left out.  I think it will be needed in future when we have something running in userland.  Basically INKERNEL checks that an address has the LSB set indicating it belongs to the kernel, I guess arm64 makes that distinction.  
These are just fixups to code already accepted in pull request #42.